### PR TITLE
Bugfix for "Error: TypeError: Cannot read properties of undefined (reading 'trim')"

### DIFF
--- a/src/utils/tests_parsers.ts
+++ b/src/utils/tests_parsers.ts
@@ -16,8 +16,10 @@ export interface ParseOutput {
 // Used by load method, does not evaluate whether tests have passed/failed.
 export function parseMixOutput(projectDir: string, stdout: string): Map<string, ParseOutput> {
   const testsMap = new Map<string, ParseOutput>();
-  const tests = stdout
-    .split('Including tags: [:""]')[1] // compilation and other noise before
+
+  const cleanOutput = cleanupOutput(stdout);
+
+  const tests = cleanOutput
     .trim()
     .split('\n\n') // tests grouped per files
     .map((string) => string.split('\n').filter((string) => string)) // sometimes there are no tests, like an empty doctest
@@ -64,3 +66,10 @@ export function parseMixOutput(projectDir: string, stdout: string): Map<string, 
 
   return testsMap;
 }
+function cleanupOutput(stdout: string) {
+  const patternBeforeMeaningfulOutput = /Including tags: \[.*?]/; //
+  const indexBeforeMeaningfulOutput = Math.max(stdout.search(patternBeforeMeaningfulOutput), 0);
+  const meaningfulString = stdout.substring(indexBeforeMeaningfulOutput);
+  return meaningfulString;
+}
+

--- a/src/utils/tests_parsers.ts
+++ b/src/utils/tests_parsers.ts
@@ -67,7 +67,7 @@ export function parseMixOutput(projectDir: string, stdout: string): Map<string, 
   return testsMap;
 }
 function cleanupOutput(stdout: string) {
-  const patternBeforeMeaningfulOutput = /Including tags: \[.*?]/; //
+  const patternBeforeMeaningfulOutput = /Including tags: \[.*?]/; //we look for a pattern, in order to accomodate for variations (eg :"" and :*)
   const indexBeforeMeaningfulOutput = Math.max(stdout.search(patternBeforeMeaningfulOutput), 0);
   const meaningfulString = stdout.substring(indexBeforeMeaningfulOutput);
   return meaningfulString;


### PR DESCRIPTION
in certain configurations, the test output contains 
`Including tags: [:*] `
instead of 
`Including tags: [:""]`

This leads to the error
![image](https://user-images.githubusercontent.com/5522419/169701918-d0517055-ffde-43a8-9ba2-3904809a950a.png)
![image](https://user-images.githubusercontent.com/5522419/169701923-171ade0f-76b3-405d-87ac-7083dd1dde53.png)

This proposed fix should be a little more forgiving, by using a regex instead of a fixed string to determine the start of the "meaningful" content